### PR TITLE
add scalar monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ monitor list:
 - [x] unsafe height of op-node doesn't reorg
 - [x] safe/finalized height of op-node doesn't halt growing
 - [x] safe/finalized height of op-node doesn't reorg
+- [x] L1 fee scalar adjustment alerts (ETH/QKC ratio change & uint32 overflow protection)
 - [ ] op-batcher/op-proposer are sending transactions in time
 - [ ] transactions from op-batcher/op-proposer doesn't fail
 
@@ -21,7 +22,7 @@ $ cat config.json
     "batcher": "<batcher_address>",
     "proposer": "<proposer_address>",
     "challenger": "<challenger_address>",
-    "batch_inbox": "<inboc_address>",
+    "batch_inbox": "<inbox_address>",
     "l1_rpc": "<l1_rpc>",
     "l2_el_rpc": "<l2_el_rpc>",
     "l2_cl_rpc": "<l2_cl_rpc>",
@@ -29,6 +30,13 @@ $ cat config.json
     "max_l2_unsafe_halt_time": <max_l2_unsafe_halt_time>,
     "max_l2_safe_delay": <max_l2_safe_delay>,
     "max_l2_finalized_delay": <max_l2_finalized_delay>,
+    "last_eth_qkc_ratio": <last_eth_qkc_ratio>,
+    "qkc_l1_blob_base_fee_scalar": <qkc_l1_blob_base_fee_scalar>,
+    "qkc_l1_base_fee_scalar": <qkc_l1_base_fee_scalar>,
+    "l1_blob_base_fee_scalar_multiplier": <l1_blob_base_fee_scalar_multiplier>,
+    "l1_base_fee_scalar_multiplier": <l1_base_fee_scalar_multiplier>,
+    "ratio_change_threshold": <ratio_change_threshold>,
+    "uint32_overflow_threshold": <uint32_overflow_threshold>,
     "email_config": {
         "server": "<smtp server>",
         "port": <port>,


### PR DESCRIPTION
Fixes https://github.com/QuarkChain/optimism/issues/57#issuecomment-3578125245 .

op_monitor will send alert if:

1. `ETC/QKC` has changed more than `ratio_change_threshold` of the last configured value
2. `latestBlobValue`/`latestBaseValue` is near `uint32_overflow_threshold` of maxUint32.
3. `coingecko` api failed consecutively 3 times with a delay of 10 seconds.